### PR TITLE
Update thermo_integ.cpp

### DIFF
--- a/thermo_integ.cpp
+++ b/thermo_integ.cpp
@@ -235,7 +235,6 @@ double ComputeThermoInteg::compute_du(double& delta)
     double uA, uB, du_dl;
     double lA = -delta;
     double lB = delta;
-    allocate_storage();
     backup_restore_qfev<1>();      // backup charge, force, energy, virial array values
     modify_epsilon_q<parameter, mode>(lA);      //
     update_lmp(); // update the lammps force and virial values
@@ -245,7 +244,6 @@ double ComputeThermoInteg::compute_du(double& delta)
     uB = compute_epair();
     backup_restore_qfev<-1>();      // restore charge, force, energy, virial array values
     update_lmp(); // update the lammps force and virial values
-    deallocate_storage();
     du_dl = (uB - uA) / (lB - lA);
     return du_dl;
 }


### PR DESCRIPTION
Despite the previous version in which in each loop there was one allocation and one deallocation, in this version there is an allocation in the begining and  a deallocation in the end. 
The goal is to reduce the overhead related to the memory allocation   and deallocation.